### PR TITLE
編集時のパスワード検証スルー設定が完了 #68

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,9 +4,9 @@ class ApplicationController < ActionController::Base
   protected
     # 追加したカラムを許可
     def configure_permitted_parameters
-      devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
-      devise_parameter_sanitizer.permit(:sign_in, keys: [:name])
-      devise_parameter_sanitizer.permit(:account_update, keys: [:name])
+      devise_parameter_sanitizer.permit(:sign_up, keys: [:uname])
+      devise_parameter_sanitizer.permit(:sign_in, keys: [:uname])
+      devise_parameter_sanitizer.permit(:account_update, keys: [:uname])
     end
 
     private

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -13,18 +13,11 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # POST /resource
   def create
     super
-    # ↓自作
-    # @user = User.new(user_signup_params)
-    # if @user.save
-    #   flash[:success] = "ユーザー登録に成功しました。"
-    #   redirect_to @user
-    # else
-    #   render :new
-    # end
   end
 
   # DELETE /resource
   def destroy
+    super
   end
 
   protected
@@ -32,12 +25,11 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def after_sign_up_path_for(resource)
     user_path(@user)
   end
-  
-  private
-    # ↓自作
-    # def user_signup_params
-    #   params.require(:user).permit(:name, :email, :password, :password_confirmation)
-    # end
+
+  #更新時はパスワードのバリデーションをスルーする
+  def update_resource(resource, params)
+    resource.update_without_password(params)
+  end
 
   # GET /resource/edit
   # def edit

--- a/app/models/food.rb
+++ b/app/models/food.rb
@@ -1,7 +1,7 @@
 class Food < ApplicationRecord
   belongs_to :storage
 
-  validates :name, presence: true, null: false,
+  validates :fname, presence: true, null: false,
                    length: { maximum: 40 }
   validates :quantity, presence: true, null: false,
                        numericality: { greater_than: 1, less_than: 30 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable,
          :omniauthable, omniauth_providers: %i[line]
   
-  validates :name, presence: true, null: false,
+  validates :uname, presence: true, null: false,
                    length: { maximum: 20 }
   # 更新時、パスワードが入力されていなかった場合はは検証をスルーする
 

--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -6,8 +6,8 @@ h1 ユーザー登録
     = form_with model: @user, url: user_registration_path, id: "new_user", class: "new_user", local: true do |f|
       = render "devise/shared/error_messages", resource: resource
       
-      = f.label :name, class: "label--fontstyle"
-      = f.text_field :name, autofocus: true, class: "form-control"
+      = f.label :uname, class: "label--fontstyle"
+      = f.text_field :uname, autofocus: true, class: "form-control"
       
       = f.label :email, class: "label--fontstyle"
       = f.email_field :email, class: "form-control"

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -8,7 +8,7 @@ h1 ユーザー情報
         td
           | 名前
         td
-          = @user.name
+          = @user.uname
       
       tr
         td

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -179,7 +179,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 8..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/db/migrate/20210223014121_add_column_to_users.rb
+++ b/db/migrate/20210223014121_add_column_to_users.rb
@@ -2,6 +2,6 @@ class AddColumnToUsers < ActiveRecord::Migration[6.0]
   def change
     add_column :users, :provider, :string
     add_column :users, :uid, :string
-    add_column :users, :name, :string, default: "", null: false
+    add_column :users, :uname, :string, default: "", null: false
   end
 end

--- a/db/migrate/20210225220308_create_foods.rb
+++ b/db/migrate/20210225220308_create_foods.rb
@@ -1,7 +1,7 @@
 class CreateFoods < ActiveRecord::Migration[6.0]
   def change
     create_table :foods do |t|
-      t.string :name, null: false
+      t.string :fname, null: false
       t.integer :quantity, null: false
       t.date :purchase, null:false
       t.date :expiration

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,7 +13,7 @@
 ActiveRecord::Schema.define(version: 2021_03_07_033101) do
 
   create_table "foods", force: :cascade do |t|
-    t.string "name", null: false
+    t.string "fname", null: false
     t.integer "quantity", null: false
     t.date "purchase", null: false
     t.date "expiration"
@@ -21,7 +21,7 @@ ActiveRecord::Schema.define(version: 2021_03_07_033101) do
     t.integer "storage_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["name"], name: "index_foods_on_name"
+    t.index "\"name\"", name: "index_foods_on_name"
     t.index ["storage_id"], name: "index_foods_on_storage_id"
   end
 
@@ -44,7 +44,7 @@ ActiveRecord::Schema.define(version: 2021_03_07_033101) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "provider"
     t.string "uid"
-    t.string "name", default: "", null: false
+    t.string "uname", default: "", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
Userモデルのnameカラムをunameカラムに変更
Foodsモデルのnameカラムをfnameカラムに変更
ユーザー情報編集時はpasswordカラムの検証をスルーするようメソッドを追加